### PR TITLE
Python: autoload in alphabetical order, keep position on pyreload.

### DIFF
--- a/plugins/python/cconsole.h
+++ b/plugins/python/cconsole.h
@@ -24,6 +24,8 @@
 #include "src/ccommandcollection.h"
 #include <string>
 #include <sstream>
+#include <vector>
+#include <algorithm>
 
 namespace nVerliHub {
 namespace nSocket {

--- a/plugins/python/cpipython.h
+++ b/plugins/python/cpipython.h
@@ -108,7 +108,13 @@ public:
 		mPython.clear();
 	}
 
-	void AddData(cPythonInterpreter *ip) { mPython.push_back(ip); }
+	void AddData(cPythonInterpreter *ip, size_t position = (size_t)-1)
+	{
+		if (position >= mPython.size())
+			mPython.push_back(ip);
+		else
+			mPython.insert(mPython.begin() + position, ip);
+	}
 
 	cPythonInterpreter *operator[](int i)
 	{


### PR DESCRIPTION
This should it make it easier to create a chain of event processors: just keep the script names in order. The !pyfiles command also uses same alphabetical ordering now. Scripts reloaded with !pyreload are now kept in place instead of being appended to the end of the chain of scripts.