### PR TITLE
Fixed GetConfig and updated Python behaviour.

### DIFF
--- a/plugins/lua/callbacks.cpp
+++ b/plugins/lua/callbacks.cpp
@@ -1621,6 +1621,7 @@ int _GetConfig(lua_State *L)
 
 	lua_pushboolean(L, 1);
 	lua_pushstring(L, val);
+	free((void *)val);
 	return 2;
 }
 

--- a/plugins/lua/cpilua.cpp
+++ b/plugins/lua/cpilua.cpp
@@ -110,12 +110,16 @@ void cpiLua::OnLoad(cServerDC *serv)
 	if (level && IsNumber(level))
 		this->log_level = atoi(level);
 
+	if (level) free((void *)level);
+
 	def.str("");
 	def << this->err_class;
 	const char *eclass = GetConfig("pi_lua", "err_class", def.str().c_str()); // get error class
 
 	if (eclass && IsNumber(eclass))
 		this->err_class = atoi(eclass);
+
+	if (eclass) free((void *)eclass);
 
 	AutoLoad();
 }

--- a/plugins/perl/vh/vh.xs
+++ b/plugins/perl/vh/vh.xs
@@ -166,6 +166,7 @@ PPCODE:
 		XSRETURN_UNDEF;
 	}
 	XPUSHs(sv_2mortal(newSVpv(val, strlen(val))));
+	free((void *)val);
 
 int
 GetUsersCount()

--- a/plugins/python/cpipython.cpp
+++ b/plugins/python/cpipython.cpp
@@ -176,6 +176,7 @@ void cpiPython::OnLoad(cServerDC *server)
 	o << log_level;
 	const char *level = GetConfig("pi_python", "log_level", o.str().c_str());
 	if (level && strlen(level) > 0) log_level = char2int(level[0]);
+	freee(level);
 
 	if (!lib_begin(callbacklist)) {
 		log("PY: cpiPython::OnLoad   Initiating vh_python_wrapper failed!\n");
@@ -996,6 +997,15 @@ bool cpiPython::OnHubCommand(cConnDC *conn, string *command, int is_op_cmd, int 
 bool cpiPython::OnScriptCommand(string *cmd, string *data, string *plug, string *script)
 {
 	if (cmd && data && plug && script) {
+		if (plug->empty() && script->empty()) {
+			if (!cmd->compare("_hub_security_change")) {
+				cpiPython::botname = *data;
+				log("PY: botname was updated to: %s\n", cpiPython::botname.c_str());
+			} else if (!cmd->compare("_opchat_name_change")) {
+				cpiPython::opchatname = *data;
+				log("PY: opchatname was updated to: %s\n", cpiPython::opchatname.c_str());
+			}
+		}
 		w_Targs *args = lib_pack("ssss", cmd->c_str(), data->c_str(), plug->c_str(), script->c_str());
 		return CallAll(W_OnScriptCommand, args);
 	}
@@ -1102,10 +1112,10 @@ bool cpiPython::OnNewBan(cBan *ban)  // todo: is not called
 bool cpiPython::OnSetConfig(cUser *user, string *conf, string *var, string *val_new, string *val_old, long val_type)
 {
 	if (user && conf && var && val_new && val_old) {
-		w_Targs *args = lib_pack("sssssl", user->mNick.c_str(), conf->c_str(), var->c_str(), val_new->c_str(), val_old->c_str(), val_type);
+		w_Targs *args = lib_pack("sssssl", user->mNick.c_str(), conf->c_str(), var->c_str(), 
+			val_new->c_str(), val_old->c_str(), val_type);
 		return CallAll(W_OnSetConfig, args);
 	}
-
 	return true;
 }
 

--- a/plugins/python/cpythoninterpreter.cpp
+++ b/plugins/python/cpythoninterpreter.cpp
@@ -55,9 +55,9 @@ bool cPythonInterpreter::Init()
 		return false;
 	}
 	id = cpiPython::lib_reserveid();
-	w_Targs *a = cpiPython::lib_pack("lssssl", id, mScriptName.c_str(), cpiPython::botname.c_str(), 
+	w_Targs *a = cpiPython::lib_pack("lssssls", id, mScriptName.c_str(), cpiPython::botname.c_str(), 
 		cpiPython::opchatname.c_str(), cpiPython::me->server->mConfigBaseDir.c_str(), 
-		(long)cpiPython::me->server->mStartTime.Sec());
+		(long)cpiPython::me->server->mStartTime.Sec(), cpiPython::me->server->mDBConf.config_name.c_str());
 	if (!a) {
 		id = -1;
 		return false;

--- a/plugins/python/wrapper.h
+++ b/plugins/python/wrapper.h
@@ -84,7 +84,7 @@ enum {
 	W_OnTimer,
 	W_OnNewReg,
 	W_OnNewBan,
-	W_OnSetConfig
+	W_OnSetConfig,
 };
 
 // MAX_HOOKS must be more than the number of elements in above enum
@@ -143,7 +143,7 @@ enum {
 	W_classmc,
 	W_pm,
 	W_name_and_version,
-	W_StopHub
+	W_StopHub,
 };
 
 // MAX_CALLBACKS must be more than the number of elements in above enum
@@ -191,6 +191,8 @@ typedef struct {
 	char          *hooks;
 	const char    *botname;
 	const char    *opchatname;
+	bool           use_old_ontimer;
+	const char    *config_name;
 } w_TScript;
 
 // the following functions are all you need to use in the plugin that loads this wrapper

--- a/src/cserverdc.cpp
+++ b/src/cserverdc.cpp
@@ -2516,6 +2516,12 @@ int cServerDC::SetConfig(const char *conf, const char *var, const char *val, str
 					mUserList.SendToAllWithFeature(data, eSF_BOTLIST, mC.delayed_myinfo, true);
 					mInProgresUsers.SendToAllWithFeature(data, eSF_BOTLIST, mC.delayed_myinfo, true);
 
+					#ifndef WITHOUT_PLUGINS
+						string empty = "";
+						string cmd_name = "_hub_security_change";
+						mCallBacks.mOnScriptCommand.CallAll(&cmd_name, &val_new, &empty, &empty);
+					#endif
+
 				} else if (svar == "opchat_name") {
 					if (val_new == mC.hub_security) { // dont allow equal to hub security nick
 						ci->ConvertFrom(val_old);
@@ -2550,6 +2556,12 @@ int cServerDC::SetConfig(const char *conf, const char *var, const char *val, str
 						delete mOpChat;
 						mOpChat = NULL;
 					}
+
+					#ifndef WITHOUT_PLUGINS
+						string empty = "";
+						string cmd_name = "_opchat_name_change";
+						mCallBacks.mOnScriptCommand.CallAll(&cmd_name, &val_new, &empty, &empty);
+					#endif
 
 				} else if (svar == "hub_security_desc") {
 					mP.Create_MyINFO(mHubSec->mMyINFO, mHubSec->mNick, val_new, speed, mail, share);
@@ -2612,6 +2624,8 @@ int cServerDC::SetConfig(const char *conf, const char *var, const char *val, str
 
 const char* cServerDC::GetConfig(const char *conf, const char *var, const char *def)
 {
+	if (def) def = strdup(def); // the caller will free non-null values returned by GetConfig!
+
 	if (!conf || !var)
 		return def;
 
@@ -2623,7 +2637,7 @@ const char* cServerDC::GetConfig(const char *conf, const char *var, const char *
 
 		if (ci) {
 			ci->ConvertTo(val);
-			return val.c_str();
+			return strdup(val.c_str());
 		} else {
 			if (ErrLog(1))
 				LogStream() << "Undefined GetConfig variable: " << conf << "." << var << endl;
@@ -2645,7 +2659,7 @@ const char* cServerDC::GetConfig(const char *conf, const char *var, const char *
 		ci = NULL;
 
 		if (load)
-			return val.c_str();
+			return strdup(val.c_str());
 	}
 
 	return def;

--- a/src/script_api.cpp
+++ b/src/script_api.cpp
@@ -441,13 +441,13 @@ bool SetConfig(const char *conf, const char *var, const char *val)
 const char* GetConfig(const char *conf, const char *var, const char *def)
 {
 	if (!conf || !var)
-		return def;
+		return (def ? strdup(def) : NULL);
 
 	cServerDC *serv = GetCurrentVerlihub();
 
 	if (!serv) {
 		cerr << "Server not found" << endl;
-		return def;
+		return (def ? strdup(def) : NULL);
 	}
 
 	return serv->GetConfig(conf, var, def);


### PR DESCRIPTION
GetConfig returned a variable that went out of scope; fixed it by strdup'ing the return and let the caller handle the free'ing. Python: now vh.botname and vh.opchatname are updated when someone changes them. Python: Added vh.config_name to help figure out what is the main configuration. Python: old OnTimer() without arguments is supported again.