### PR TITLE
Python: made cmake look for the newest Python.

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -39,7 +39,7 @@ ENDIF()
 
 # Python plugin
 
-SET(Python_ADDITIONAL_VERSIONS 2.4 2.5 2.6 2.7)
+SET(Python_ADDITIONAL_VERSIONS 2.7 2.6 2.5 2.4)
 Find_Package(PythonLibs)
 ADD_PLUGIN(PYTHONLIBS_FOUND python)
 MACRO_LOG_FEATURE(PYTHONLIBS_FOUND "python" "Allows you to use scripts written with Python (http://www.python.org)" "http://www.python.org" "2.7" "Python libray NOT found")


### PR DESCRIPTION
Reversed the order in which Python versions are listed in CMakeLists.txt. Previously it was 2.4 2.5 2.6 2.7 which resulted in building against the oldest Python cmake could find.