### PR TITLE
Python: Fixed initialization, OnScriptQuery, and OnTimer error reporting.

### DIFF
--- a/plugins/python/cconsole.cpp
+++ b/plugins/python/cconsole.cpp
@@ -229,13 +229,13 @@ bool cConsole::cfAddPythonScript::operator()()
 		return false;
 	}
 
+	GetPI()->AddData(ip);
 	if (ip->Init()) {
 		(*mOS) << autosprintf(_("Script is now loaded: #%d %s"), ip->id, scriptfile.c_str());
-		GetPI()->AddData(ip);
 		return true;
 	} else {
 		(*mOS) << autosprintf(_("Script not found or couldn't be parsed: %s"), scriptfile.c_str());
-		delete ip;
+		GetPI()->RemoveByName(ip->mScriptName);
 		return false;
 	}
 }
@@ -292,13 +292,13 @@ bool cConsole::cfReloadPythonScript::operator()()
 		return false;
 	}
 
+	GetPI()->AddData(ip, position);
 	if (ip->Init()) {
 		(*mOS) << " " << autosprintf(_("Script is now loaded: #%d %s"), ip->id, scriptfile.c_str());
-		GetPI()->AddData(ip, position);
 		return true;
 	} else {
 		(*mOS) << " " << autosprintf(_("Script not found or couldn't be parsed: %s"), scriptfile.c_str());
-		delete ip;
+		GetPI()->RemoveByName(ip->mScriptName);
 		return false;
 	}
 }

--- a/plugins/python/cpipython.cpp
+++ b/plugins/python/cpipython.cpp
@@ -265,8 +265,8 @@ bool cpiPython::AutoLoad()
 		pathname = mScriptDir + filename;
 		cPythonInterpreter *ip = new cPythonInterpreter(pathname);
 		if (!ip) continue;
+		AddData(ip);
 		if (ip->Init()) {
-			AddData(ip);
 			if ((log_level < 1) && Log(1))
 				LogStream() << "Success loading and parsing Python script: " << filename << endl;
 			log1("PY: Autoload, success loading script: %s [%d]\n", filename.c_str(), ip->id);
@@ -274,7 +274,7 @@ bool cpiPython::AutoLoad()
 			if ((log_level < 1) && Log(1))
 				LogStream() << "Failed loading or parsing Python script: " << filename << endl;
 			log1("PY: Autoload, failed loading script: %s\n", filename.c_str());
-			delete ip;
+			RemoveByName(pathname);
 		}
 	}
 	return true;
@@ -921,6 +921,7 @@ bool cpiPython::OnScriptQuery(string *cmd, string *data, string *recipient, stri
 				if (!recipient->size() || !recipient->compare("python") || !recipient->compare((*it)->mScriptName))
 					should_call = true;
 			}
+			if (!should_call) continue;
 			if (!cmd->compare("_get_script_file")) {
 				resp->push_back(ScriptResponse((*it)->mScriptName, (*it)->mScriptName));
 				continue;
@@ -933,7 +934,6 @@ bool cpiPython::OnScriptQuery(string *cmd, string *data, string *recipient, stri
 				resp->push_back(ScriptResponse((*it)->version, (*it)->mScriptName));
 				continue;
 			}
-			if (!should_call) continue;
 			result = (*it)->CallFunction(func, args);
 			if (!result) continue;
 			if (lib_unpack(result, "s", &response)) {

--- a/plugins/python/cpipython.h
+++ b/plugins/python/cpipython.h
@@ -37,6 +37,24 @@
 
 #define PYTHON_PI_IDENTIFIER "Python"
 
+#define w_ret0    cpiPython::lib_pack("l", (long)0)
+#define w_ret1    cpiPython::lib_pack("l", (long)1)
+#define w_retnone cpiPython::lib_pack("")
+
+// logging levels:
+// 0 - plugin critical errors, interpreter errors, bad call arguments
+// 1 - callback / hook logging - only their status
+// 2 - all function parameters and return values are printed
+// 3 - debugging info is printed
+#define log(...)                                  { printf( __VA_ARGS__ ); fflush(stdout); }
+#define log1(...) { if (cpiPython::log_level > 0) { printf( __VA_ARGS__ ); fflush(stdout); }; }
+#define log2(...) { if (cpiPython::log_level > 1) { printf( __VA_ARGS__ ); fflush(stdout); }; }
+#define log3(...) { if (cpiPython::log_level > 2) { printf( __VA_ARGS__ ); fflush(stdout); }; }
+#define log4(...) { if (cpiPython::log_level > 3) { printf( __VA_ARGS__ ); fflush(stdout); }; }
+#define log5(...) { if (cpiPython::log_level > 4) { printf( __VA_ARGS__ ); fflush(stdout); }; }
+
+#define dprintf(...) { printf("%s:%u: "__FILE__, __LINE__); printf( __VA_ARGS__ ); fflush(stdout); }
+
 using std::vector;
 namespace nVerliHub {
 namespace nPythonPlugin {
@@ -120,6 +138,22 @@ public:
 			mPython.push_back(ip);
 		else
 			mPython.insert(mPython.begin() + position, ip);
+	}
+
+	bool RemoveByName(const string &name)
+	{
+		tvPythonInterpreter::iterator it;
+		cPythonInterpreter *li;
+		for (it = mPython.begin(); it != mPython.end(); ++it) {
+			li = *it;
+			if (li == NULL || li->mScriptName.compare(name))
+				continue;
+			delete li;
+			mPython.erase(it);
+			return true;
+		}
+		log("PY: ERROR: Failed to remove interpreter for %s\n", name.c_str());
+		return false;
 	}
 
 	cPythonInterpreter *operator[](unsigned int i)
@@ -221,23 +255,5 @@ extern "C" w_Targs *_name_and_version  (int id, w_Targs *args);
 extern "C" w_Targs *_StopHub           (int id, w_Targs *args);
 
 };  // namespace nVerliHub
-
-#define w_ret0    cpiPython::lib_pack("l", (long)0)
-#define w_ret1    cpiPython::lib_pack("l", (long)1)
-#define w_retnone cpiPython::lib_pack("")
-
-// logging levels:
-// 0 - plugin critical errors, interpreter errors, bad call arguments
-// 1 - callback / hook logging - only their status
-// 2 - all function parameters and return values are printed
-// 3 - debugging info is printed
-#define log(...)                                  { printf( __VA_ARGS__ ); fflush(stdout); }
-#define log1(...) { if (cpiPython::log_level > 0) { printf( __VA_ARGS__ ); fflush(stdout); }; }
-#define log2(...) { if (cpiPython::log_level > 1) { printf( __VA_ARGS__ ); fflush(stdout); }; }
-#define log3(...) { if (cpiPython::log_level > 2) { printf( __VA_ARGS__ ); fflush(stdout); }; }
-#define log4(...) { if (cpiPython::log_level > 3) { printf( __VA_ARGS__ ); fflush(stdout); }; }
-#define log5(...) { if (cpiPython::log_level > 4) { printf( __VA_ARGS__ ); fflush(stdout); }; }
-
-#define dprintf(...) { printf("%s:%u: "__FILE__, __LINE__); printf( __VA_ARGS__ ); fflush(stdout); }
 
 #endif

--- a/plugins/python/wrapper.cpp
+++ b/plugins/python/wrapper.cpp
@@ -1754,10 +1754,17 @@ w_Targs *w_CallHook(int id, int func, w_Targs *params)
 						id, name, w_HookName(func));
 					Py_DECREF(val);
 					PyErr_Clear();
+				} else {
+					log("PY: [%d:%s] TypeError in %s\n", id, name, w_HookName(func));
+					PyErr_Display(exc, val, trace);
+					fflush(stdout);
 				}
+			} else {
+				log("PY: [%d:%s] Other error in %s\n", id, name, w_HookName(func));
+				PyErr_Display(exc, val, trace);
+				fflush(stdout);
 			}
-		}
-		if (PyErr_Occurred()) {
+		} else if (PyErr_Occurred()) {
 			log("PY: [%d:%s] Call (%s): failed\n", id, name, w_HookName(func));
 			PyErr_Print();
 			fflush(stdout);


### PR DESCRIPTION
AddData(interpreter) is moved before interpreter->Init(), because the script can call functions during initialization that require it to be registered on the script list.

OnScriptQuery's auto responses now also check if the recipient matches, because there is no point in every script responding to them.

All OnTimer errors were silent (instead of just the ones about wrong number of function arguments -- to prevent error logs from growing too fast) and this is fixed now.