### PR TITLE
PVS-Studio, part 3

### DIFF
--- a/src/cdcconsole.cpp
+++ b/src/cdcconsole.cpp
@@ -1624,8 +1624,8 @@ bool cDCConsole::cfBan::operator()()
 		return false;
 	}
 
-	unsigned BanType = eBF_NICKIP;
-
+	int BanType = eBF_NICKIP;
+	
 	if (mIdRex->PartFound(BAN_TYPE)) {
 		mIdRex->Extract(BAN_TYPE, mIdStr, tmp);
 		BanType = this->StringToIntFromList(tmp, bannames, banids, sizeof(bannames) / sizeof(char*));

--- a/src/cdcproto.cpp
+++ b/src/cdcproto.cpp
@@ -3476,7 +3476,8 @@ bool cDCProto::CheckUserLogin(cConnDC *conn, cMessageDC *msg, bool inlist)
 	ostringstream rsn;
 	string pref;
 
-	if (msg && msg->mStr.size()) {
+	if (msg) {
+	if (msg->mStr.size()) {
 		pref = msg->mStr.substr(0, msg->mStr.find_first_of(' '));
 
 		if (pref.size())
@@ -3496,6 +3497,7 @@ bool cDCProto::CheckUserLogin(cConnDC *conn, cMessageDC *msg, bool inlist)
 	}
 
 	mS->ConnCloseMsg(conn, rsn.str(), 1000, eCR_LOGIN_ERR);
+	}
 	return true;
 }
 

--- a/src/tmysqlmemorylist.h
+++ b/src/tmysqlmemorylist.h
@@ -193,7 +193,6 @@ public:
 				mData.erase(it);
 				delete CurrentData;
 				CurrentData = NULL;
-				*it = NULL;
 				break;
 			}
 		}


### PR DESCRIPTION
* Dereferencing of the invalid iterator 'it' might take place.
* Expression 'BanType < 0' is always false. Unsigned type value is never < 0.
* The 'msg' pointer was utilized before it was verified against nullptr. Check lines: 3487, 3492.