### PR TITLE
Fix memory leak cHTTPConn

### DIFF
--- a/src/chttpconn.cpp
+++ b/src/chttpconn.cpp
@@ -52,7 +52,8 @@ namespace nVerliHub {
 
 	namespace nSocket {
 
-char *cHTTPConn::mBuf = new char[MAX_DATA + 1];
+std::vector<char> cHTTPConn::mBuf;
+int cHTTPConn::mEnd = 0;
 
 cHTTPConn::cHTTPConn(int sock):
 	mGood(sock > 0),
@@ -259,8 +260,11 @@ int cHTTPConn::Read()
 
 	if (!mGood || !mWrite)
 		return -1;
-
-	while (((len = recv(mSock, mBuf, MAX_DATA, 0)) == -1) && ((errno == EAGAIN) || (errno == EINTR)) && (max++ <= 100)) {
+	if(mBuf.empty())
+	{
+		mBuf.resize(MAX_DATA + 1); // TODO use dynamic grow
+	}
+	while (((len = recv(mSock, mBuf.data(), MAX_DATA, 0)) == -1) && ((errno == EAGAIN) || (errno == EINTR)) && (max++ <= 100)) {
 		::usleep(5);
 	}
 

--- a/src/chttpconn.cpp
+++ b/src/chttpconn.cpp
@@ -62,7 +62,6 @@ cHTTPConn::cHTTPConn(int sock):
 	mHost(""),
 	mPort(0)
 {
-	mEnd = 0;
 	memset(&mClose, 0, sizeof(mClose));
 }
 
@@ -72,7 +71,6 @@ cHTTPConn::cHTTPConn(const string &host, const int port):
 	mSock(0),
 	mHost(host),
 	mPort(port),
-	mEnd(0),
 	mClose(0, 0)
 {
 	Connect(host, port);

--- a/src/chttpconn.h
+++ b/src/chttpconn.h
@@ -25,6 +25,7 @@
 #include "ctime.h"
 #include "cconnbase.h"
 #include <string>
+#include <vector>
 
 using namespace std;
 
@@ -46,15 +47,15 @@ namespace nVerliHub {
 					return mSock;
 				}
 
-				size_t GetSize()
+				size_t GetSize() const
 				{
 					return mSend.size();
 				}
 
-				unsigned int GetBuf(string &buf)
+				static unsigned int GetBuf(string &buf)
 				{
 					buf.clear();
-					buf.assign(mBuf, 0, mEnd);
+					buf.assign(mBuf.data(), 0, mEnd);
 					return mEnd;
 				}
 
@@ -74,17 +75,17 @@ namespace nVerliHub {
 				tSocket mSock;
 
 			protected:
-				static char *mBuf;
 				string mSend, mHost;
 				unsigned int mPort;
 				tSocket Create();
 				int Send(const char *buf, size_t &len);
 
 			private:
-				int mEnd;
+				static std::vector<char> mBuf;
+				static int mEnd;
 				cTime mClose;
 		};
-
+		
 	}; // namespace nSocket
 }; // namespace nVerliHub
 


### PR DESCRIPTION
#165 
leaked 524289 bytes (512.00 KiB) allocated by malloc (line: 158)
	FUNCTION                                            FILE                      SYMBOL
	operator new(unsigned long)                         ??:?                      /lib64/libstdc++.so.6(_Znwm+0x1d)[0x7f46ec0aeecd]
	operator new[](unsigned long)                       ??:?                      /lib64/libstdc++.so.6(_Znam+0x9)[0x7f46ec0aefc9]
	__static_initialization_and_destruction_0(int, int) chttpconn.cpp:?           /home/dht/src-orig/verlihub/build/src/libverlihub.so(+0x12760c)[0x7f46f02e460c]
	_GLOBAL__sub_I_chttpconn.cpp                        chttpconn.cpp:?           /home/dht/src-orig/verlihub/build/src/libverlihub.so(+0x12762e)[0x7f46f02e462e]
	_dl_init_internal                                   ./:?                      /lib64/ld-linux-x86-64.so.2(+0xf903)[0x7f46f07a4903]
	_dl_start_user                                      ./:?                      /lib64/ld-linux-x86-64.so.2(+0x115a)[0x7f46f079615a]