### PR TITLE
Fix in-class initialization

### DIFF
--- a/src/cconfigbase.h
+++ b/src/cconfigbase.h
@@ -94,7 +94,7 @@ class cConfigBaseBase : public cObj
 		*/
 		struct iterator
 		{
-			iterator(){}
+			iterator():mC(NULL){}
 			iterator (class cConfigBaseBase *C,const tIVIt &it):mC(C),mIT(it){}
 			cConfigItemBase * operator* () { return mC->mhItems.GetByHash(*mIT);}
 			iterator &operator ++() { ++mIT; return *this; }
@@ -104,7 +104,7 @@ class cConfigBaseBase : public cObj
 				return mIT != it.mIT;
 			}
 
-			cConfigBaseBase *mC = NULL;
+			cConfigBaseBase *mC;
 			tIVIt mIT;
 			iterator &Set(class cConfigBaseBase *C,const tIVIt &it){mC=C;mIT=it; return *this;}
 


### PR DESCRIPTION
/usr/src/apps/verlihub/src/cconfigbase.h:107:24: warning: in-class initialization of non-static data member is a C++11 extension [-Wc++11-extensions]
cConfigBaseBase *mC = NULL;
https://github.com/Verlihub/verlihub/issues/168