### PR TITLE
Fix timer condition for closing connection

### DIFF
--- a/src/casyncconn.cpp
+++ b/src/casyncconn.cpp
@@ -933,7 +933,7 @@ tConnType cAsyncConn::GetType()
 
 int cAsyncConn::OnTimerBase(const cTime &now)
 {
-	if (bool(mCloseAfter) && (mCloseAfter > now)) {
+	if (bool(mCloseAfter) && (mCloseAfter < now)) {
 		CloseNow();
 		return 0;
 	}


### PR DESCRIPTION
This ensures `CloseNow()` is called only when the deadline has **passed** (`now` has advanced past `mCloseAfter`), giving the flush buffer time to drain.