### PR TITLE
Fix timer condition to close connection correctly

### DIFF
--- a/src/chttpconn.cpp
+++ b/src/chttpconn.cpp
@@ -358,7 +358,7 @@ void cHTTPConn::CloseNice(int msec)
 int cHTTPConn::OnTimerBase(const cTime &now)
 {
 
-	if (bool(mClose) && (mClose > now))
+	if (bool(mClose) && (mClose < now))
 		CloseNow();
 
 	return 0;


### PR DESCRIPTION
### Problem

In `src/chttpconn.cpp:361`, the graceful close condition is inverted:

    if (bool(mClose) && (mClose > now))
        CloseNow();

### Root Cause

`CloseNice(ms)` sets `mClose = now + ms` (a future timestamp). The condition `mClose > now` is immediately true, so `CloseNow()` fires right away without giving the buffer time to drain.